### PR TITLE
fix: tilde expansion doesn’t working in quote

### DIFF
--- a/lib/capistrano/tasks/nvm.cap
+++ b/lib/capistrano/tasks/nvm.cap
@@ -44,7 +44,7 @@ namespace :load do
       nvm_path ||= if fetch(:nvm_type, :user) == :system
         "/usr/local/nvm"
       else
-        "~/.nvm"
+        "$HOME/.nvm"
       end
     }
 


### PR DESCRIPTION
If nvm_custom_path is not set and nvm_type is not system, "~/nvm" is used as default nvm_path.
Then the next command is executed to load the nvm feature in nvm-exec.sh

``` sh
source "~/nvm/nvm.sh"
```

However, the tilde expansion of posix shell does not work in a quoted string.
Using $HOME instead of ~ just works because variables are interpolated in a double quoted string.

Signed-off-by: Udagawa Kaito umireon@gmail.com
