### PR TITLE
nvm is not compatible with the npm config "prefix" option

### DIFF
--- a/lib/capistrano/tasks/nvm.cap
+++ b/lib/capistrano/tasks/nvm.cap
@@ -25,7 +25,7 @@ namespace :nvm do
   task :wrapper do
     on release_roles(fetch(:nvm_roles)) do
       execute :mkdir, "-p", "#{fetch(:tmp_dir)}/#{fetch(:application)}/"
-      upload! StringIO.new("#!/bin/bash -e\nsource \"#{fetch(:nvm_path)}/nvm.sh\"\nnvm use $NODE_VERSION\nexec \"$@\""), "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
+      upload! StringIO.new("#!/bin/bash -e\nsource \"#{fetch(:nvm_path)}/nvm.sh\"\nnvm use --delete-prefix $NODE_VERSION\nexec \"$@\""), "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
       execute :chmod, "+x", "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
     end
   end


### PR DESCRIPTION
Hi,

I have the following error : 

```
npm stdout: Nothing written
npm stderr: nvm is not compatible with the npm config "prefix" option: currently set to "/usr"
Run `npm config delete prefix` or `nvm use --delete-prefix v0.12.7` to unset it.
```

Regards,
