### PR TITLE
Use nvm/nvm-exec command instead of wrapper

### DIFF
--- a/lib/capistrano/tasks/nvm.cap
+++ b/lib/capistrano/tasks/nvm.cap
@@ -1,5 +1,5 @@
 namespace :nvm do
-  task validate: :'nvm:wrapper' do
+  task :validate do
     on release_roles(fetch(:nvm_roles)) do
       nvm_node = fetch(:nvm_node)
       if nvm_node.nil?
@@ -19,17 +19,9 @@ namespace :nvm do
 
   task :map_bins do
     SSHKit.config.default_env.merge!({ node_version: "#{fetch(:nvm_node)}" })
-    nvm_prefix = fetch(:nvm_prefix, -> { "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh" } )
+    nvm_prefix = fetch(:nvm_prefix, -> { "#{fetch(:nvm_path)}/nvm-exec" } )
     fetch(:nvm_map_bins).each do |command|
       SSHKit.config.command_map.prefix[command.to_sym].unshift(nvm_prefix)
-    end
-  end
-
-  task :wrapper do
-    on release_roles(fetch(:nvm_roles)) do
-      execute :mkdir, "-p", "#{fetch(:tmp_dir)}/#{fetch(:application)}/"
-      upload! StringIO.new("#!/bin/bash -e\nsource \"#{fetch(:nvm_path)}/nvm.sh\"\nnvm use $NODE_VERSION\nexec \"$@\""), "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
-      execute :chmod, "+x", "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
     end
   end
 end


### PR DESCRIPTION
Fix #12

The wrapper doesn't work in nvm 0.30.2, so use [nvm/nvm-exec](https://github.com/creationix/nvm/blob/master/nvm-exec) instead.