### PR TITLE
Fix issue where nvm-exec.sh doesn't execute command

### DIFF
--- a/lib/capistrano/tasks/nvm.cap
+++ b/lib/capistrano/tasks/nvm.cap
@@ -28,7 +28,7 @@ namespace :nvm do
   task :wrapper do
     on release_roles(fetch(:nvm_roles)) do
       execute :mkdir, "-p", "#{fetch(:tmp_dir)}/#{fetch(:application)}/"
-      upload! StringIO.new("#!/bin/bash -e\nsource \"#{fetch(:nvm_path)}/nvm.sh\"\nnvm use $NODE_VERSION\nexec \"$@\""), "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
+      upload! StringIO.new("#!/bin/bash -e\ncmd=\"$@\"\nsource \"#{fetch(:nvm_path)}/nvm.sh\"\nnvm use $NODE_VERSION\nexec $cmd"), "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
       execute :chmod, "+x", "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
     end
   end


### PR DESCRIPTION
I've encountered an issue where `nvm-exec.sh <command>` doesn't run the command.

The issue seems to be that `$@` can be unset after sourcing nvm.sh:

```
source "#{fetch(:nvm_path)}/nvm.sh"
nvm use $NODE_VERSION
exec "$@"   # "$@" is blank and nothing is executed
```

I made a fix by storing `$@` in a variable:

```
cmd="$@"
source "#{fetch(:nvm_path)}/nvm.sh"
nvm use $NODE_VERSION
exec $cmd
```