### PR TITLE
Proposal: Add yarn to nvm_map_bins

### DIFF
--- a/lib/capistrano/tasks/nvm.cap
+++ b/lib/capistrano/tasks/nvm.cap
@@ -53,6 +53,6 @@ namespace :load do
 
     set :nvm_roles, fetch(:nvm_roles, :all)
     set :nvm_node_path, -> { ["#{fetch(:nvm_path)}/#{fetch(:nvm_node)}", "#{fetch(:nvm_path)}/versions/node/#{fetch(:nvm_node)}"] }
-    set :nvm_map_bins, %w{node npm}
+    set :nvm_map_bins, %w{node npm yarn}
   end
 end


### PR DESCRIPTION
I think this is quite reasonable to add it to default bins

- these days, many developers want to use yarn.
- Rails which used frequently to deploy using capistrano will introduce [webpacker](http://github.com/rails/webpacker/pulls), which use yarn as default.

so, why not? XD