### PR TITLE
Pull back to koenpunt add rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,7 @@
+---
+AllCops:
+  DisplayCopNames: true
+
+Metrics/LineLength:
+  Description: "We've got some long lines, so let's raise the limit."
+  Max: 200

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ gem 'capistrano-nvm', require: false
 
 And then execute:
 
-    $ bundle install
+```shell
+$ bundle install
+```
 
 ## Usage
 
@@ -23,15 +25,96 @@ Require in `Capfile` to use the default task:
 require 'capistrano/nvm'
 ```
 
-Configurable options:
+The task then uses command maps to run `nvm.sh` when necessary, as controlled by the setting `:nvm_map_bins`.
+
+## Configuration
+
+### Settings
+
+In your capistrano `config/deploy.rb`:
+
+#### Required
+
+- `:nvm_node`
+  - Accepts: String
+  - Default: None
+  - Notes: The version number must be prefixed with a `v` if `:nvm_verb` is set to `:use`. See examples below.
+
+#### Optional
+
+- `:nvm_type`
+  - Accepts: `:user`, `:system`
+  - Default: `:user`
+  - Notes: Used to determine the location of `nvm.sh`, similar to setting `$NVM_HOME` in your shell.
+
+- `:nvm_custom_path`
+  - Accepts: String
+  - Default: Unused
+  - Notes: Setting this effectively overrides `:nvm_type`.
+
+- `:nvm_map_bins`
+  - Accepts: Ruby word array
+  - Default: `%w{node npm yarn}`
+  - Notes: This is a list of commands that will be executed with NVM support by capistrano.
+
+- `:nvm_verb`
+  - Accepts: `:use`, `:install`
+  - Default: `:use`
+  - Notes: Determines whether the deploy invokes `nvm use` or `nvm install`.
+
+## Examples
+
+### Configuring Capistrano
+
+Using a version of NodeJS that is already installed and managed by NVM:
 
 ```ruby
-set :nvm_type, :user # or :system, depends on your nvm setup
-set :nvm_node, 'v0.10.21'
-set :nvm_map_bins, %w{node npm yarn}
+set :nvm_node, 'v8.10' # Version of node.js to use with NVM
 ```
 
-If your nvm is located in some custom path, you can use `nvm_custom_path` to set it.
+Using a version of NodeJS that we want to download and install:
+
+```ruby
+set :nvm_node, 'lts/carbon' # Friendly names work well...
+set :nvm_verb, 'install' # ...but only with the "install" verb
+```
+
+When NVM is installed at the system level:
+
+```ruby
+set :nvm_node, 'lts'
+set :nvm_verb, 'install'
+set :nvm_type, :system
+```
+
+When NVM is installed in a custom location:
+
+```ruby
+set :nvm_node, 'lts'
+set :nvm_verb, 'install'
+set :nvm_custom_path, '/usr/local/src/nvm' # This overrides :nvm_type so we won't bother setting it
+```
+
+### Using a .nvmrc file
+
+#### In your Capistrano code
+
+In `config/deploy.rb`, check for `.nvmrc` and use its value, or a sensible default like v8.10:
+
+```ruby
+set :nvm_node, File.exist?('.nvmrc') ? File.read('.nvmrc').strip : "v8.10"
+```
+
+#### From your release code
+
+In your rakefile where you `execute :npm`, `:node`, or `:yarn`, add this conditional first:
+
+```ruby
+if test "[ -e #{release_path}/.nvmrc ]"
+  download! "#{release_path}/.nvmrc", '.nvmrc'
+  SSHKit.config.default_env[:node_version] = File.read('.nvmrc').strip
+end
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The task then uses command maps to run `nvm.sh` when necessary, as controlled by
 
 ### Settings
 
-In your capistrano `config/deploy.rb`:
+In your Capistrano `config/deploy.rb`:
 
 #### Required
 
@@ -49,13 +49,13 @@ In your capistrano `config/deploy.rb`:
 
 - `:nvm_custom_path`
   - Accepts: String
-  - Default: Unused
+  - Default: None
   - Notes: Setting this effectively overrides `:nvm_type`.
 
 - `:nvm_map_bins`
   - Accepts: Ruby word array
   - Default: `%w{node npm yarn}`
-  - Notes: This is a list of commands that will be executed with NVM support by capistrano.
+  - Notes: This is a list of commands that will be executed with nvm support by Capistrano.
 
 - `:nvm_verb`
   - Accepts: `:use`, `:install`
@@ -66,10 +66,10 @@ In your capistrano `config/deploy.rb`:
 
 ### Configuring Capistrano
 
-Using a version of NodeJS that is already installed and managed by NVM:
+Using a version of NodeJS that is already installed and managed by nvm:
 
 ```ruby
-set :nvm_node, 'v8.10' # Version of node.js to use with NVM
+set :nvm_node, 'v8.10' # Version of node.js to use with nvm
 ```
 
 Using a version of NodeJS that we want to download and install:
@@ -79,7 +79,7 @@ set :nvm_node, 'lts/carbon' # Friendly names work well...
 set :nvm_verb, 'install' # ...but only with the "install" verb
 ```
 
-When NVM is installed at the system level:
+When nvm is installed at the system level:
 
 ```ruby
 set :nvm_node, 'lts'
@@ -87,7 +87,7 @@ set :nvm_verb, 'install'
 set :nvm_type, :system
 ```
 
-When NVM is installed in a custom location:
+When nvm is installed in a custom location:
 
 ```ruby
 set :nvm_node, 'lts'

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,1 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'

--- a/capistrano-nvm.gemspec
+++ b/capistrano-nvm.gemspec
@@ -9,12 +9,12 @@ Gem::Specification.new do |spec|
   spec.version       = CapistranoNvm::VERSION
   spec.authors       = ['Koen Punt']
   spec.email         = ['me@koen.pt']
-  spec.description   = %q{nvm support for Capistrano 3.x}
-  spec.summary       = %q{nvm support for Capistrano 3.x}
+  spec.description   = 'nvm support for Capistrano 3.x'
+  spec.summary       = 'nvm support for Capistrano 3.x'
   spec.homepage      = 'https://github.com/koenpunt/capistrano-nvm'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']

--- a/lib/capistrano-nvm/version.rb
+++ b/lib/capistrano-nvm/version.rb
@@ -1,3 +1,3 @@
 module CapistranoNvm
-  VERSION = '0.0.7'
+  VERSION = '0.0.9'.freeze
 end

--- a/lib/capistrano-nvm/version.rb
+++ b/lib/capistrano-nvm/version.rb
@@ -1,3 +1,3 @@
 module CapistranoNvm
-  VERSION = '0.0.9'.freeze
+  VERSION = '0.1.0'.freeze
 end

--- a/lib/capistrano/nvm.rb
+++ b/lib/capistrano/nvm.rb
@@ -1,1 +1,1 @@
-load File.expand_path("../tasks/nvm.rake", __FILE__)
+load File.expand_path('../tasks/nvm.rake', __FILE__)

--- a/lib/capistrano/tasks/nvm.rake
+++ b/lib/capistrano/tasks/nvm.rake
@@ -9,10 +9,13 @@ namespace :nvm do
 
       nvm_node_path = fetch(:nvm_node_path)
       nvm_node_path = [nvm_node_path] unless nvm_node_path.is_a?(Array)
+      nvm_verb = fetch(:nvm_verb).to_s
 
       unless test(nvm_node_path.map {|p| "[ -d #{p} ]" }.join(" || "))
-        error "nvm: #{nvm_node} is not installed or not found in any of #{nvm_node_path.join(" ")}"
-        exit 1
+        if nvm_verb == 'use'
+          error "nvm: #{nvm_node} is not installed or not found in any of #{nvm_node_path.join(" ")}"
+          exit 1
+        end
       end
     end
   end
@@ -20,6 +23,7 @@ namespace :nvm do
   task :map_bins do
     SSHKit.config.default_env.merge!({ node_version: "#{fetch(:nvm_node)}" })
     nvm_prefix = fetch(:nvm_prefix, -> { "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh" } )
+    SSHKit.config.default_env[:nvm_verb] = fetch(:nvm_verb).to_s
     fetch(:nvm_map_bins).each do |command|
       SSHKit.config.command_map.prefix[command.to_sym].unshift(nvm_prefix)
     end
@@ -28,7 +32,7 @@ namespace :nvm do
   task :wrapper do
     on release_roles(fetch(:nvm_roles)) do
       execute :mkdir, "-p", "#{fetch(:tmp_dir)}/#{fetch(:application)}/"
-      upload! StringIO.new("#!/bin/bash -e\nsource \"#{fetch(:nvm_path)}/nvm.sh\"\nnvm use $NODE_VERSION\nexec \"$@\""), "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
+      upload! StringIO.new("#!/bin/bash -e\nsource \"#{fetch(:nvm_path)}/nvm.sh\"\nnvm $NVM_VERB $NODE_VERSION\nexec \"$@\""), "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
       execute :chmod, "+x", "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
     end
   end
@@ -54,5 +58,6 @@ namespace :load do
     set :nvm_roles, fetch(:nvm_roles, :all)
     set :nvm_node_path, -> { ["#{fetch(:nvm_path)}/#{fetch(:nvm_node)}", "#{fetch(:nvm_path)}/versions/node/#{fetch(:nvm_node)}"] }
     set :nvm_map_bins, %w{node npm yarn}
+    set :nvm_verb, fetch(:nvm_verb, :use)
   end
 end

--- a/lib/capistrano/tasks/nvm.rake
+++ b/lib/capistrano/tasks/nvm.rake
@@ -14,7 +14,7 @@ namespace :nvm do
 
       unless test(nvm_node_path.map { |p| "[ -d #{p} ]" }.join(' || '))
         if nvm_verb == 'use'
-          error "nvm: #{nvm_node} is not installed or not found in any of #{nvm_node_path.join(' ')}"
+          error "nvm: #{nvm_node} is not installed or not found in any of #{nvm_node_path.join(' ')}, and nvm is set to #{nvm_verb}"
           exit 1
         end
       end

--- a/lib/capistrano/tasks/nvm.rake
+++ b/lib/capistrano/tasks/nvm.rake
@@ -1,9 +1,10 @@
+# rubocop:disable Lint/UselessAssignment,Style/Lambda
 namespace :nvm do
   task validate: :'nvm:wrapper' do
     on release_roles(fetch(:nvm_roles)) do
       nvm_node = fetch(:nvm_node)
       if nvm_node.nil?
-        error "nvm: nvm_node is not set"
+        error 'nvm: nvm_node is not set'
         exit 1
       end
 
@@ -11,9 +12,9 @@ namespace :nvm do
       nvm_node_path = [nvm_node_path] unless nvm_node_path.is_a?(Array)
       nvm_verb = fetch(:nvm_verb).to_s
 
-      unless test(nvm_node_path.map {|p| "[ -d #{p} ]" }.join(" || "))
+      unless test(nvm_node_path.map { |p| "[ -d #{p} ]" }.join(' || '))
         if nvm_verb == 'use'
-          error "nvm: #{nvm_node} is not installed or not found in any of #{nvm_node_path.join(" ")}"
+          error "nvm: #{nvm_node} is not installed or not found in any of #{nvm_node_path.join(' ')}"
           exit 1
         end
       end
@@ -21,8 +22,8 @@ namespace :nvm do
   end
 
   task :map_bins do
-    SSHKit.config.default_env.merge!({ node_version: "#{fetch(:nvm_node)}" })
-    nvm_prefix = fetch(:nvm_prefix, -> { "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh" } )
+    SSHKit.config.default_env[:node_version] = fetch(:nvm_node).to_s
+    nvm_prefix = fetch(:nvm_prefix, -> { "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh" })
     SSHKit.config.default_env[:nvm_verb] = fetch(:nvm_verb).to_s
     fetch(:nvm_map_bins).each do |command|
       SSHKit.config.command_map.prefix[command.to_sym].unshift(nvm_prefix)
@@ -31,9 +32,9 @@ namespace :nvm do
 
   task :wrapper do
     on release_roles(fetch(:nvm_roles)) do
-      execute :mkdir, "-p", "#{fetch(:tmp_dir)}/#{fetch(:application)}/"
+      execute :mkdir, '-p', "#{fetch(:tmp_dir)}/#{fetch(:application)}/"
       upload! StringIO.new("#!/bin/bash -e\nsource \"#{fetch(:nvm_path)}/nvm.sh\"\nnvm $NVM_VERB $NODE_VERSION\nexec \"$@\""), "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
-      execute :chmod, "+x", "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
+      execute :chmod, '+x', "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
     end
   end
 end
@@ -45,19 +46,18 @@ end
 
 namespace :load do
   task :defaults do
-
     set :nvm_path, -> {
       nvm_path = fetch(:nvm_custom_path)
       nvm_path ||= if fetch(:nvm_type, :user) == :system
-        "/usr/local/nvm"
-      else
-        "$HOME/.nvm"
-      end
+                     '/usr/local/nvm'
+                   else
+                     '$HOME/.nvm'
+                   end
     }
 
     set :nvm_roles, fetch(:nvm_roles, :all)
     set :nvm_node_path, -> { ["#{fetch(:nvm_path)}/#{fetch(:nvm_node)}", "#{fetch(:nvm_path)}/versions/node/#{fetch(:nvm_node)}"] }
-    set :nvm_map_bins, %w{node npm yarn}
+    set :nvm_map_bins, %w(node npm yarn)
     set :nvm_verb, fetch(:nvm_verb, :use)
   end
 end

--- a/lib/capistrano/tasks/nvm.rake
+++ b/lib/capistrano/tasks/nvm.rake
@@ -23,8 +23,8 @@ namespace :nvm do
 
   task :map_bins do
     SSHKit.config.default_env[:node_version] = fetch(:nvm_node).to_s
-    nvm_prefix = fetch(:nvm_prefix, -> { "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh" })
     SSHKit.config.default_env[:nvm_verb] = fetch(:nvm_verb).to_s
+    nvm_prefix = fetch(:nvm_prefix, -> { "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh" })
     fetch(:nvm_map_bins).each do |command|
       SSHKit.config.command_map.prefix[command.to_sym].unshift(nvm_prefix)
     end


### PR DESCRIPTION
Rubocops the entire project following the commits of #27. Diffing against the newest commit from #26 shows changes to the `Rakefile` and `gemspec` that Rubocop decided were important since I ran it against the entire project instead of just the files I had touched like I did before:

```
17:01 $ git diff c54b83a HEAD
diff --git a/Rakefile b/Rakefile
index 2995527..c702cfc 100644
--- a/Rakefile
+++ b/Rakefile
@@ -1 +1 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
diff --git a/capistrano-nvm.gemspec b/capistrano-nvm.gemspec
index 1762793..aea37e4 100644
--- a/capistrano-nvm.gemspec
+++ b/capistrano-nvm.gemspec
@@ -9,12 +9,12 @@ Gem::Specification.new do |spec|
   spec.version       = CapistranoNvm::VERSION
   spec.authors       = ['Koen Punt']
   spec.email         = ['me@koen.pt']
-  spec.description   = %q{nvm support for Capistrano 3.x}
-  spec.summary       = %q{nvm support for Capistrano 3.x}
+  spec.description   = 'nvm support for Capistrano 3.x'
+  spec.summary       = 'nvm support for Capistrano 3.x'
   spec.homepage      = 'https://github.com/koenpunt/capistrano-nvm'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
✔ <snipped>/capistrano-nvm [pull_back_to_koenpunt-add_rubocop|✔] 

```

Otherwise, this is identical to #26 
