### PR TITLE
Wrap with env

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ set :nvm_map_bins, %w{node npm yarn}
 
 If your nvm is located in some custom path, you can use `nvm_custom_path` to set it.
 
+If you use capistrano-nvm with rails and webpacker/yarn, add rake to the `:nvm_map_bins` to use nvm in `bundle asset:precompile`
+
 ## Contributing
 
 1. Fork it

--- a/lib/capistrano/tasks/nvm.rake
+++ b/lib/capistrano/tasks/nvm.rake
@@ -28,7 +28,7 @@ namespace :nvm do
   task :wrapper do
     on release_roles(fetch(:nvm_roles)) do
       execute :mkdir, "-p", "#{fetch(:tmp_dir)}/#{fetch(:application)}/"
-      upload! StringIO.new("#!/bin/bash -e\nsource \"#{fetch(:nvm_path)}/nvm.sh\"\nnvm use $NODE_VERSION\nexec \"$@\""), "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
+      upload! StringIO.new("#!/bin/bash -e\nsource \"#{fetch(:nvm_path)}/nvm.sh\"\nnvm use $NODE_VERSION\nexec env \"$@\""), "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
       execute :chmod, "+x", "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
     end
   end


### PR DESCRIPTION
When I used capistrano-nvm together with other simimar wrappers (in my case capistrano-rbenv) it happend that the wrappt command startet with setting environment variables.

`exec` of these commends led to `command not found` for a command ${release_dir}/RBENV=... .

This can easily be fixed by running the wrapped command with `env`.