### PR TITLE
fix nvm run with fresh capistrano

### DIFF
--- a/lib/capistrano/tasks/nvm.rake
+++ b/lib/capistrano/tasks/nvm.rake
@@ -28,7 +28,7 @@ namespace :nvm do
   task :wrapper do
     on release_roles(fetch(:nvm_roles)) do
       execute :mkdir, "-p", "#{fetch(:tmp_dir)}/#{fetch(:application)}/"
-      upload! StringIO.new("#!/bin/bash -e\nsource \"#{fetch(:nvm_path)}/nvm.sh\"\nnvm use $NODE_VERSION\nexec \"$@\""), "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
+      upload! StringIO.new("#!/bin/bash -e\nsource \"#{fetch(:nvm_path)}/nvm.sh\"\nnvm use $NODE_VERSION\nexec env \"$@\""), "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
       execute :chmod, "+x", "#{fetch(:tmp_dir)}/#{fetch(:application)}/nvm-exec.sh"
     end
   end


### PR DESCRIPTION
I have encountered weird errors like:

```
/tmp/my_project/nvm-exec.sh: line 5: /home/vlad/my_project/releases/20240530191133/RBENV_ROOT=/home/my_project/.rbenv: No such file or directory
```

Clearly something was wrong with the `nvm-exec.sh` file. Turns out it didn't work well with environment variables passed as arguments.

This small correction fixes that.